### PR TITLE
Fix certificates always being regenerated.

### DIFF
--- a/certs/certs.go
+++ b/certs/certs.go
@@ -105,10 +105,10 @@ func checkValid(certPath string, keyPath string) bool {
 	if err != nil {
 		return false
 	}
-	if !time.Now().After(x509Cert.NotAfter) {
+	if time.Now().After(x509Cert.NotAfter) {
 		return false
 	}
-	if !time.Now().Before(x509Cert.NotBefore) {
+	if time.Now().Before(x509Cert.NotBefore) {
 		return false
 	}
 	return true


### PR DESCRIPTION
The checks on the certificate's lifespan fields were backwards;
the only way to avoid regenerating the cert is if the current
time is both after the NotAfter and before the NotBefore, which
is both wrong and impossible with our current models of spacetime.
